### PR TITLE
Release[SDK-3584]: Signed Call Flutter v0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 ## CHANGE LOG
 
+### Version 0.0.4 (January 22, 2024 )
+-------------------------------------------
+
+**What's new**
+
+* **[Android Platform]**
+  * Supports [Signed Call Android SDK v0.0.5](https://repo1.maven.org/maven2/com/clevertap/android/clevertap-signedcall-sdk/0.0.5) which is compatible with [CleverTap Android SDK v5.2.2](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTCORECHANGELOG.md#version-522-december-22-2023).
+  * Introduces new properties `initiatorImage` and `receiverImage` in the `MissedCallActionClickResult` instance provided through the `CleverTapSignedCallFlutter.shared.missedCallActionClickListener.listen(MissedCallActionClickResult)` event-stream.
+  * Adds new public API registerVoIPCallStatusListener(SCVoIPCallStatusListener callStatusListener) to observe the changes in the call state, providing updates to both the initiator and receiver of the call.
+  * Adds new callback APIs to handle events when the app is terminated or killed, as listed below:
+    * Use `CleverTapSignedCallFlutter.shared.onBackgroundCallEvent(handler)` to handle VoIP call events when the app is in a killed state. 
+    * Use `CleverTapSignedCallFlutter.shared.onBackgroundMissedCallActionClicked(handler)` to manage missed call action click events when the app is in a killed state.
+      Please refer to the integration documentation for more details on handling callback events in a killed state.
+
+* **[iOS Platform]**
+  * Supports [Signed Call iOS SDK v0.0.6](https://github.com/CleverTap/clevertap-signedcall-ios-sdk/blob/main/CHANGELOG.md#version-006-january-19-2024) which is compatible with [CleverTap iOS SDK v5.2.2](https://github.com/CleverTap/clevertap-ios-sdk/blob/master/CHANGELOG.md#version-522-november-21-2023).
+  
+**Breaking Changes**
+
+* **[Android and iOS Platform]**
+  * The `CleverTapSignedCallFlutter.shared.callEventListener` event stream will now provide an instance of the `CallEventResult` class instead of the `CallEvent` class. Please refer to the integration documentation for details on usage.
+  
+* **[iOS Platform]**
+  * iOS deployment target version is bumped to iOS 12.
+
+**Behaviour Changes**
+
+* **[Android Platform]**
+  * Handles UX issues during network loss or switch by invalidating the socket reconnection and establishing an active connection to process the call related actions.
+  * Modifies the SDK's behavior when the **Notifications Settings** are disabled for the application. Previously, if the app's notifications were disabled, the device rang on incoming calls without displaying the call screen in the background and killed states. In this version, the SDK now declines incoming calls when the notifications are disabled. If the notification settings are later enabled, the SDK resumes processing calls instead of automatically declining them.
+
+* **[Android and iOS Platform]**
+  * The `CleverTapSignedCallFlutter.shared.callEventListener` will now provide updates in the call state to both the initiator and receiver of the call. Previously, it was exposed only to the initiator of the call.
+  
+**Bug Fixes**
+
+* **[Android Platform]**
+  * Fixes multiple outgoing call requests initiated simultaneously through multiple calls of `CleverTapSignedCallFlutter.shared.call(..)`. The SDK now processes only one call at a time while rejecting other requests with a failure exception.
+  * Addresses an **IllegalStateException** which occurs while prompting the user with the poor/bad network conditions on the call-screen.
+
+* **[Android and iOS Platform]**
+   * Addresses an infinite **Connecting** state issue on the call screen which was triggered by using CUIDs longer than 15 characters. In this version, the SDK extends support to CUIDs ranging from 5 to 50 characters.       
+
 ### Version 0.0.3 (September 11, 2023)
 -------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To get started, sign up [here](https://clevertap.com/live-product-demo/).
 
 ```yaml
 dependencies:
-  clevertap_signedcall_plugin: 0.0.3
+  clevertap_signedcall_plugin: 0.0.4
 ```
 
 - Run `flutter pub get` to install the SDK.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.clevertap.clevertap_signedcall_flutter'
-version '0.0.3'
+version '0.0.4'
 
 buildscript {
     ext.kotlin_version = '1.6.10'
@@ -49,8 +49,8 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
-    compileOnly "com.clevertap.android:clevertap-android-sdk:5.2.0"
-    compileOnly "com.clevertap.android:clevertap-signedcall-sdk:0.0.4"
+    compileOnly "com.clevertap.android:clevertap-android-sdk:5.2.2"
+    compileOnly "com.clevertap.android:clevertap-signedcall-sdk:0.0.5"
     compileOnly 'androidx.work:work-runtime:2.7.1'
     compileOnly('io.socket:socket.io-client:2.1.0') {
         exclude group: 'org.json', module: 'json'

--- a/android/src/main/kotlin/com/clevertap/clevertap_signedcall_flutter/Constants.kt
+++ b/android/src/main/kotlin/com/clevertap/clevertap_signedcall_flutter/Constants.kt
@@ -25,6 +25,8 @@ object Constants {
     const val KEY_CALL_PROPERTIES = "callProperties"
     const val KEY_RECEIVER_CUID = "receiverCuid"
     const val KEY_CALL_CONTEXT = "callContext"
+    const val KEY_INITIATOR_IMAGE = "initiatorImage"
+    const val KEY_RECEIVER_IMAGE = "receiverImage"
     const val KEY_CALL_OPTIONS = "callOptions"
     const val KEY_ERROR_CODE = "errorCode"
     const val KEY_ERROR_MESSAGE = "errorMessage"
@@ -36,4 +38,8 @@ object Constants {
     const val KEY_CALL_DETAILS = "callDetails"
     const val KEY_CALLER_CUID = "callerCuid"
     const val KEY_CALLEE_CUID = "calleeCuid"
+    const val DISPATCHER_HANDLE = "pluginCallbackHandle"
+    const val CALLBACK_HANDLE = "userCallbackHandle"
+    const val ISOLATE_SUFFIX_CALL_EVENT_CALLBACK = "callEvent"
+    const val ISOLATE_SUFFIX_MISSED_CALL_ACTION_CLICKED_CALLBACK = "missedCallNotificationClicked"
 }

--- a/android/src/main/kotlin/com/clevertap/clevertap_signedcall_flutter/SCAppContextHolder.kt
+++ b/android/src/main/kotlin/com/clevertap/clevertap_signedcall_flutter/SCAppContextHolder.kt
@@ -1,0 +1,24 @@
+package com.clevertap.clevertap_signedcall_flutter
+
+import android.content.Context
+import android.util.Log
+import com.clevertap.clevertap_signedcall_flutter.util.Utils
+import com.clevertap.clevertap_signedcall_flutter.util.Utils.log
+
+/**
+ * This class holds the application context in a static reference
+ */
+object SCAppContextHolder {
+
+    private const val TAG = "SCAppContextHolder"
+    private var applicationContext: Context? = null
+
+    fun getApplicationContext(): Context? {
+        return applicationContext
+    }
+
+    fun setApplicationContext(applicationContext: Context) {
+        log(TAG, "set application context.")
+        SCAppContextHolder.applicationContext = applicationContext
+    }
+}

--- a/android/src/main/kotlin/com/clevertap/clevertap_signedcall_flutter/SCBackgroundCallEventHandler.kt
+++ b/android/src/main/kotlin/com/clevertap/clevertap_signedcall_flutter/SCBackgroundCallEventHandler.kt
@@ -1,0 +1,26 @@
+package com.clevertap.clevertap_signedcall_flutter
+
+import android.content.Context
+import com.clevertap.android.signedcall.init.SignedCallAPI
+import com.clevertap.clevertap_signedcall_flutter.extensions.toMap
+import com.clevertap.clevertap_signedcall_flutter.isolate.SCBackgroundIsolateRunner
+import com.clevertap.clevertap_signedcall_flutter.isolate.IsolateHandlePreferences.BACKGROUND_ISOLATE_CALL_EVENT
+import com.clevertap.clevertap_signedcall_flutter.util.Utils
+
+open class SCBackgroundCallEventHandler {
+
+    companion object {
+
+        @JvmStatic
+        fun initialize(context: Context) {
+            Utils.log(message = "SCBackgroundCallEventHandler is initialized!")
+
+            SignedCallAPI.getInstance().registerVoIPCallStatusListener { data ->
+                Utils.log(message = "SCBackgroundCallEventHandler is invoked with payload: $data")
+                SCBackgroundIsolateRunner.startBackgroundIsolate(
+                    context, BACKGROUND_ISOLATE_CALL_EVENT, data.toMap()
+                )
+            }
+        }
+    }
+}

--- a/android/src/main/kotlin/com/clevertap/clevertap_signedcall_flutter/SCMethodCall.kt
+++ b/android/src/main/kotlin/com/clevertap/clevertap_signedcall_flutter/SCMethodCall.kt
@@ -9,6 +9,10 @@ object SCMethodCall {
     const val LOGOUT = "logout"
     const val HANG_UP_CALL = "hangUpCall"
     const val LOGGING = "logging"
+    const val REGISTER_BACKGROUND_CALL_EVENT_HANDLER = "registerBackgroundCallEventHandler"
+    const val REGISTER_BACKGROUND_MISSED_CALL_ACTION_CLICKED_HANDLER =
+        "registerBackgroundMissedCallActionClickedHandler"
+    const val ACK_MISSED_CALL_ACTION_CLICKED = "missedCallActionClicked#ack"
 
     //Platform to Flutter
     const val ON_SIGNED_CALL_DID_INITIALIZE = "onSignedCallDidInitialize"

--- a/android/src/main/kotlin/com/clevertap/clevertap_signedcall_flutter/extensions/ParseExtension.kt
+++ b/android/src/main/kotlin/com/clevertap/clevertap_signedcall_flutter/extensions/ParseExtension.kt
@@ -1,7 +1,10 @@
 package com.clevertap.clevertap_signedcall_flutter.extensions
 
+import com.clevertap.android.signedcall.enums.VoIPCallStatus
 import com.clevertap.android.signedcall.init.SignedCallAPI
+import com.clevertap.android.signedcall.models.CallDetails
 import com.clevertap.android.signedcall.models.MissedCallNotificationOpenResult
+import com.clevertap.android.signedcall.models.SCCallStatusDetails
 import com.clevertap.clevertap_signedcall_flutter.Constants.KEY_ACTION
 import com.clevertap.clevertap_signedcall_flutter.Constants.KEY_ACTION_ID
 import com.clevertap.clevertap_signedcall_flutter.Constants.KEY_ACTION_LABEL
@@ -9,6 +12,8 @@ import com.clevertap.clevertap_signedcall_flutter.Constants.KEY_CALLEE_CUID
 import com.clevertap.clevertap_signedcall_flutter.Constants.KEY_CALLER_CUID
 import com.clevertap.clevertap_signedcall_flutter.Constants.KEY_CALL_CONTEXT
 import com.clevertap.clevertap_signedcall_flutter.Constants.KEY_CALL_DETAILS
+import com.clevertap.clevertap_signedcall_flutter.Constants.KEY_INITIATOR_IMAGE
+import com.clevertap.clevertap_signedcall_flutter.Constants.KEY_RECEIVER_IMAGE
 
 /**
  * Parses the [MissedCallNotificationOpenResult] instance to a map object
@@ -20,13 +25,8 @@ fun MissedCallNotificationOpenResult.toMap(): HashMap<String, Any> {
         KEY_ACTION_ID to this.action.actionID,
         KEY_ACTION_LABEL to this.action.actionLabel
     )
-    val callDetailsMap = mapOf<String, String>(
-        KEY_CALLER_CUID to this.callDetails.callerCuid,
-        KEY_CALLEE_CUID to this.callDetails.calleeCuid,
-        KEY_CALL_CONTEXT to this.callDetails.callContext
-    )
     resultMap[KEY_ACTION] = actionMap
-    resultMap[KEY_CALL_DETAILS] = callDetailsMap
+    resultMap[KEY_CALL_DETAILS] = this.callDetails.toMap()
     return resultMap
 }
 
@@ -42,4 +42,53 @@ fun Int.toSignedCallLogLevel(): Int {
         3 -> SignedCallAPI.LogLevel.VERBOSE
         else -> throw IllegalStateException("Invalid value of debug level")
     }
+}
+
+/**
+ * Converts SCCallStatusDetails to a Map.
+ *
+ * @return A Map representation of SCCallStatusDetails.
+ */
+fun SCCallStatusDetails.toMap(): Map<String, Any> {
+    return mapOf(
+        "direction" to direction.toString(),
+        "callDetails" to callDetails.toMap(),
+        "callEvent" to callStatus.formattedCallEvent()
+    )
+}
+
+/**
+ * Converts [VoIPCallStatus] to a formatted string.
+ *
+ * @return A formatted call event string.
+ */
+fun VoIPCallStatus.formattedCallEvent(): String {
+    return when (this) {
+        VoIPCallStatus.CALL_IS_PLACED -> "CallIsPlaced"
+        VoIPCallStatus.CALL_CANCELLED -> "Cancelled"
+        VoIPCallStatus.CALL_DECLINED -> "Declined"
+        VoIPCallStatus.CALL_MISSED -> "Missed"
+        VoIPCallStatus.CALL_ANSWERED -> "Answered"
+        VoIPCallStatus.CALL_IN_PROGRESS -> "CallInProgress"
+        VoIPCallStatus.CALL_OVER -> "Ended"
+        VoIPCallStatus.CALLEE_BUSY_ON_ANOTHER_CALL -> "ReceiverBusyOnAnotherCall"
+        VoIPCallStatus.CALL_DECLINED_DUE_TO_LOGGED_OUT_CUID -> "DeclinedDueToLoggedOutCuid"
+        VoIPCallStatus.CALL_DECLINED_DUE_TO_NOTIFICATIONS_DISABLED -> "DeclinedDueToNotificationsDisabled"
+        VoIPCallStatus.CALLEE_MICROPHONE_PERMISSION_NOT_GRANTED -> "DeclinedDueToMicrophonePermissionsNotGranted"
+    }
+}
+
+/**
+ * Converts CallDetails to a Map.
+ *
+ * @return A Map representation of CallDetails.
+ */
+fun CallDetails.toMap(): Map<String, Any> {
+    return mapOf(
+        KEY_CALLER_CUID to (callerCuid ?: ""),
+        KEY_CALLEE_CUID to (calleeCuid ?: ""),
+        KEY_CALL_CONTEXT to (callContext ?: ""),
+        KEY_INITIATOR_IMAGE to initiatorImage,
+        KEY_RECEIVER_IMAGE to receiverImage
+    )
 }

--- a/android/src/main/kotlin/com/clevertap/clevertap_signedcall_flutter/handlers/MissedCallActionClickHandler.kt
+++ b/android/src/main/kotlin/com/clevertap/clevertap_signedcall_flutter/handlers/MissedCallActionClickHandler.kt
@@ -6,12 +6,28 @@ import com.clevertap.android.signedcall.interfaces.MissedCallNotificationOpenedH
 import com.clevertap.android.signedcall.models.MissedCallNotificationOpenResult
 import com.clevertap.clevertap_signedcall_flutter.Constants.LOG_TAG
 import com.clevertap.clevertap_signedcall_flutter.extensions.toMap
+import com.clevertap.clevertap_signedcall_flutter.isolate.SCBackgroundIsolateRunner
+import com.clevertap.clevertap_signedcall_flutter.isolate.IsolateHandlePreferences.BACKGROUND_ISOLATE_MISSED_CALL_ACTION_CLICKED
 import com.clevertap.clevertap_signedcall_flutter.util.Utils
+import java.util.Timer
+import java.util.TimerTask
 
 /**
  * Missed Call CTA handler for SignedCall Missed Call Notifications
  */
 class MissedCallActionClickHandler : MissedCallNotificationOpenedHandler {
+
+    companion object {
+
+        const val ACK_TIMEOUT = 500L
+        val ackTimeOutHandler = Timer()
+
+        // Cancels the acknowledgment timeout handler.
+        fun resolveAckTimeOutHandler() {
+            ackTimeOutHandler.cancel()
+        }
+    }
+
     /**
      * Gets called from the SC SDK when the user taps on the missed call CTA
      *
@@ -24,16 +40,32 @@ class MissedCallActionClickHandler : MissedCallNotificationOpenedHandler {
     ) {
         try {
             Utils.log(
-                message =  "Missed call action button clicked!"+
+                message = "Missed call action button clicked!" +
                         " Streaming to event-channel with payload: \n actionID: " + result.action.actionID
                         + ", actionLabel: " + result.action.actionLabel
                         + ", context of call: " + result.callDetails.callContext
                         + ", cuid of caller: " + result.callDetails.callerCuid
                         + ", cuid of callee: " + result.callDetails.calleeCuid
+                        + ", initiator-image: " + result.callDetails.initiatorImage
+                        + ", receiver-image: " + result.callDetails.receiverImage
             )
 
             //Sends the real-time changes in the call-state in an observable event-stream
             MissedCallActionEventStreamHandler.eventSink?.success(result.toMap())
+            Utils.log(message = "stream is sent!")
+
+            ackTimeOutHandler.schedule(object : TimerTask() {
+                override fun run() {
+                    Utils.log(message = "inside ackTimeOutHandler!")
+
+                    Utils.runOnMainThread {
+                        SCBackgroundIsolateRunner.startBackgroundIsolate(
+                            context,
+                            BACKGROUND_ISOLATE_MISSED_CALL_ACTION_CLICKED, result.toMap()
+                        )
+                    }
+                }
+            }, ACK_TIMEOUT)
         } catch (e: Exception) {
             Log.d(LOG_TAG, "Exception while handling missed call CTA action, " + e.localizedMessage)
         }

--- a/android/src/main/kotlin/com/clevertap/clevertap_signedcall_flutter/isolate/IsolateHandlePreferences.kt
+++ b/android/src/main/kotlin/com/clevertap/clevertap_signedcall_flutter/isolate/IsolateHandlePreferences.kt
@@ -1,0 +1,42 @@
+package com.clevertap.clevertap_signedcall_flutter.isolate
+
+import android.content.Context
+import android.content.SharedPreferences
+
+object IsolateHandlePreferences {
+
+    private const val SHARED_PREFS_FILE_NAME = "clevertap_signedcall_flutter_plugin"
+    private const val CALLBACK_DISPATCHER_HANDLE_KEY = "com.clevertap.clevertap_signedcall_flutter.CALLBACK_DISPATCHER_HANDLE_KEY"
+    private const val USER_CALLBACK_HANDLE_KEY = "com.clevertap.clevertap_signedcall_flutter.CALLBACK_HANDLE_KEY"
+
+    const val BACKGROUND_ISOLATE_CALL_EVENT = "onBackgroundCallEvent"
+    const val BACKGROUND_ISOLATE_MISSED_CALL_ACTION_CLICKED = "onBackgroundMissedCallActionClicked"
+
+    private fun getPreferences(context: Context): SharedPreferences {
+        return context.getSharedPreferences(SHARED_PREFS_FILE_NAME, Context.MODE_PRIVATE)
+    }
+
+    /**
+     * Sets the Dart callback handle for the Dart methods that are,
+     * - responsible for initializing the background Dart isolate, preparing it to receive
+     * Dart callback tasks requests.
+     * - responsible for handling messaging events in the background.
+     */
+    fun saveCallbackKeys(
+        context: Context?, dispatcherCallbackHandle: Long, callbackHandle: Long, callbackHandleSuffix: String
+    ) {
+        context?.let {
+            val editor = getPreferences(it).edit()
+            editor.putLong(CALLBACK_DISPATCHER_HANDLE_KEY, dispatcherCallbackHandle).apply()
+            editor.putLong("$USER_CALLBACK_HANDLE_KEY#$callbackHandleSuffix", callbackHandle).apply()
+        }
+    }
+
+    fun getCallbackDispatcherHandle(context: Context): Long {
+        return getPreferences(context).getLong(CALLBACK_DISPATCHER_HANDLE_KEY, 0)
+    }
+
+    fun getUserCallbackHandle(context: Context, callbackHandleSuffix: String): Long {
+        return getPreferences(context).getLong("$USER_CALLBACK_HANDLE_KEY#$callbackHandleSuffix", 0)
+    }
+}

--- a/android/src/main/kotlin/com/clevertap/clevertap_signedcall_flutter/isolate/SCBackgroundIsolateExecutor.kt
+++ b/android/src/main/kotlin/com/clevertap/clevertap_signedcall_flutter/isolate/SCBackgroundIsolateExecutor.kt
@@ -1,0 +1,211 @@
+package com.clevertap.clevertap_signedcall_flutter.isolate
+
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import com.clevertap.clevertap_signedcall_flutter.Constants
+import com.clevertap.clevertap_signedcall_flutter.SCAppContextHolder
+import com.clevertap.clevertap_signedcall_flutter.isolate.IsolateHandlePreferences.BACKGROUND_ISOLATE_CALL_EVENT
+import com.clevertap.clevertap_signedcall_flutter.isolate.IsolateHandlePreferences.BACKGROUND_ISOLATE_MISSED_CALL_ACTION_CLICKED
+import com.clevertap.clevertap_signedcall_flutter.util.Utils.log
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.embedding.engine.FlutterShellArgs
+import io.flutter.embedding.engine.dart.DartExecutor.DartCallback
+import io.flutter.embedding.engine.loader.FlutterLoader
+import io.flutter.plugin.common.BinaryMessenger
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugin.common.MethodChannel.MethodCallHandler
+import io.flutter.view.FlutterCallbackInformation
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * A background executor which handles initializing a background isolate running a callback dispatcher,
+ * used to invoke Dart callbacks in background/killed state.
+ */
+class SCBackgroundIsolateExecutor : MethodCallHandler {
+
+    companion object {
+
+        private const val TAG = "SCBackgroundIsolateExecutor"
+    }
+
+    private val isCallbackDispatcherReady = AtomicBoolean(false)
+    private var backgroundFlutterEngine: FlutterEngine? = null
+    private lateinit var backgroundChannel: MethodChannel
+
+    private var currentMethodName: String? = null
+    private var currentPayloadMap: Map<String, Any>? = null
+
+    /**
+     * Starts running a background Dart isolate within a new [FlutterEngine] using a previously
+     * used entrypoint.
+     */
+    fun startBackgroundIsolate(context: Context, methodName: String, payloadMap: Map<String, Any>) {
+        currentMethodName = methodName
+        currentPayloadMap = payloadMap
+
+        if (isNotRunning()) {
+            log(TAG, "Starting a background isolate!")
+            val callbackHandle = getPluginCallbackHandle(context)
+            if (callbackHandle != 0L) {
+                startBackgroundIsolate(context, callbackHandle, null)
+            }
+        } else {
+            log(TAG, "A background isolate is already running, using it to execute the Dart callback!")
+            executeDartCallbackInBackgroundIsolate(context, currentMethodName, currentPayloadMap)
+        }
+    }
+
+    /**
+     * Starts running a background Dart isolate within a new [FlutterEngine] using a previously
+     * used entrypoint.
+     *
+     * Preconditions:
+     * The given [callbackHandle] must correspond to a registered Dart callback. If the
+     * handle does not resolve to a Dart callback then this method does nothing.
+     */
+    private fun startBackgroundIsolate(context: Context, callbackHandle: Long, shellArgs: FlutterShellArgs?) {
+        if (backgroundFlutterEngine != null) {
+            Log.e(TAG, "Background isolate already started.")
+            return
+        }
+
+        val loader = FlutterLoader()
+        val mainHandler = Handler(Looper.getMainLooper())
+        val myRunnable = Runnable {
+            // startInitialization() must be called on the main thread.
+            loader.startInitialization(context)
+
+            loader.ensureInitializationCompleteAsync(context, null, mainHandler) {
+                val appBundlePath = loader.findAppBundlePath()
+                val assets = context.assets
+                if (isNotRunning()) {
+                    if (shellArgs != null) {
+                        Log.i(
+                            TAG, "Creating background FlutterEngine instance, with args: ${
+                                shellArgs.toArray().contentToString()
+                            }"
+                        )
+                        backgroundFlutterEngine = FlutterEngine(context, shellArgs.toArray())
+                    } else {
+                        Log.i(TAG, "Creating background FlutterEngine instance.")
+                        backgroundFlutterEngine = FlutterEngine(context)
+                    }
+                    // We need to create an instance of `FlutterEngine` before looking up the
+                    // callback. If we don't, the callback cache won't be initialized and the
+                    // lookup will fail.
+                    val flutterCallback = FlutterCallbackInformation.lookupCallbackInformation(callbackHandle)
+                    val executor = backgroundFlutterEngine!!.dartExecutor
+                    initializeMethodChannel(executor)
+                    val dartCallback = DartCallback(assets, appBundlePath, flutterCallback)
+                    executor.executeDartCallback(dartCallback)
+                }
+            }
+        }
+        mainHandler.post(myRunnable)
+    }
+
+    private fun initializeMethodChannel(isolate: BinaryMessenger) {
+        backgroundChannel = MethodChannel(isolate, "${Constants.CHANNEL_NAME}/background_isolate_channel")
+        backgroundChannel.setMethodCallHandler(this)
+    }
+
+    /**
+     * Executes the desired Dart callback in a background Dart isolate.
+     *
+     * The given [methodName] should represent the name of the Dart method to be called.
+     * The [payloadMap] contains the payload data to be passed to the Dart method.
+     *
+     * @param context The application context.
+     * @param methodName The name of the Dart method to be called.
+     * @param payloadMap The payload map to be passed to the Dart method.
+     */
+    private fun executeDartCallbackInBackgroundIsolate(
+        context: Context, methodName: String?, payloadMap: Map<String, Any>?
+    ) {
+        if (backgroundFlutterEngine == null) {
+            log(TAG, "A background message could not be handled in Dart as no background isolate has been created")
+            return
+        }
+
+        try {
+            getUserCallbackHandle(context, methodName!!).let { userCallbackHandle ->
+                log(TAG, "Invoking Dart callback for method: $methodName")
+                backgroundChannel.invokeMethod(
+                    methodName, mapOf(
+                        "userCallbackHandle" to userCallbackHandle, "payload" to (payloadMap ?: emptyMap())
+                    )
+                )
+            }
+        } catch (e: Exception) {
+            log(TAG, "Failed to invoke the '$methodName' dart callback. ${e.localizedMessage}")
+        }
+    }
+
+    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+        val method = call.method
+        try {
+            when (method) {
+                "SCBackgroundCallbackDispatcher#initialized" -> {
+                    onInitialized()
+                    result.success(true)
+                }
+
+                else -> result.notImplemented()
+            }
+        } catch (e: Exception) {
+            result.error("error", "SCBackgroundIsolateExecutor's error: ${e.message}", null)
+        }
+    }
+
+    /**
+     * Called once the Dart background isolate(i.e. callbackDispatcher) has finished initializing.
+     */
+    private fun onInitialized() {
+        Log.i(TAG, "BackgroundCallbackDispatcher is initialized to receive a user's DartCallback request!")
+        isCallbackDispatcherReady.set(true)
+        executeDartCallbackInBackgroundIsolate(
+            SCAppContextHolder.getApplicationContext()!!, currentMethodName, currentPayloadMap
+        )
+    }
+
+    /**
+     * Retrieves the user's registered Dart callback handle for background messaging.
+     * Returns `null` if not set.
+     *
+     * @param context The application context.
+     * @param methodName The method name for which the callback handle is requested.
+     * @return The callback handle for the specified method, or `null` if not set.
+     */
+    private fun getUserCallbackHandle(context: Context, methodName: String): Long? {
+        val callbackHandleSuffix = when (methodName) {
+            BACKGROUND_ISOLATE_CALL_EVENT -> Constants.ISOLATE_SUFFIX_CALL_EVENT_CALLBACK
+            BACKGROUND_ISOLATE_MISSED_CALL_ACTION_CLICKED -> Constants.ISOLATE_SUFFIX_MISSED_CALL_ACTION_CLICKED_CALLBACK
+            else -> return null
+        }
+        return IsolateHandlePreferences.getUserCallbackHandle(context, callbackHandleSuffix)
+    }
+
+    /**
+     * Returns true if the Dart background handler(i.e. CallbackDispatcher) is registered for background messaging.
+     */
+    fun isDartBackgroundHandlerRegistered(context: Context): Boolean {
+        return getPluginCallbackHandle(context) != 0L
+    }
+
+    /**
+     * Returns true when the background isolate is not started to handle background messages.
+     */
+    private fun isNotRunning(): Boolean {
+        return !isCallbackDispatcherReady.get()
+    }
+
+    /**
+     * Get the registered Dart callback handle for the messaging plugin. Returns 0 if not set.
+     */
+    private fun getPluginCallbackHandle(context: Context): Long {
+        return IsolateHandlePreferences.getCallbackDispatcherHandle(context)
+    }
+}

--- a/android/src/main/kotlin/com/clevertap/clevertap_signedcall_flutter/isolate/SCBackgroundIsolateRunner.kt
+++ b/android/src/main/kotlin/com/clevertap/clevertap_signedcall_flutter/isolate/SCBackgroundIsolateRunner.kt
@@ -1,0 +1,39 @@
+package com.clevertap.clevertap_signedcall_flutter.isolate
+
+import android.content.Context
+import com.clevertap.clevertap_signedcall_flutter.SCAppContextHolder
+import com.clevertap.clevertap_signedcall_flutter.util.Utils.log
+
+/**
+ * A runner class which abstracts the startup process for a background isolate.
+ */
+object SCBackgroundIsolateRunner {
+
+    private const val TAG = "SCBackgroundIsolateRunner"
+
+    private var backgroundIsolateExecutor: SCBackgroundIsolateExecutor? = null
+
+    fun startBackgroundIsolate(context: Context?, methodName: String, payloadMap: Map<String, Any>) {
+        if (context == null) {
+            log(TAG, "Can't start a background isolate with a null appContext!")
+            return
+        }
+
+        //persist the app context
+        SCAppContextHolder.setApplicationContext(context)
+
+        if (backgroundIsolateExecutor == null) {
+            backgroundIsolateExecutor = SCBackgroundIsolateExecutor()
+        }
+
+        if (!backgroundIsolateExecutor!!.isDartBackgroundHandlerRegistered(context)) {
+            log(
+                TAG,
+                "A background message could not be handled in Dart as background channel handler has not been registered."
+            )
+            return
+        }
+
+        backgroundIsolateExecutor!!.startBackgroundIsolate(context, methodName, payloadMap)
+    }
+}

--- a/android/src/main/kotlin/com/clevertap/clevertap_signedcall_flutter/plugin/ISignedCallMethodCallHandler.kt
+++ b/android/src/main/kotlin/com/clevertap/clevertap_signedcall_flutter/plugin/ISignedCallMethodCallHandler.kt
@@ -1,6 +1,5 @@
 package com.clevertap.clevertap_signedcall_flutter.plugin
 
-import com.clevertap.android.signedcall.enums.VoIPCallStatus
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 
@@ -31,7 +30,7 @@ interface ISignedCallMethodCallHandler {
     /**
      * Sends the real-time changes in the call-state in an observable event stream
      */
-    fun streamCallEvent(event: VoIPCallStatus)
+    fun streamCallEvent(callEventResult: Map<String, Any>)
 
     /**
      * Disconnects the signalling socket

--- a/android/src/main/kotlin/com/clevertap/clevertap_signedcall_flutter/plugin/SignedCallFlutterPluginRegistrant.kt
+++ b/android/src/main/kotlin/com/clevertap/clevertap_signedcall_flutter/plugin/SignedCallFlutterPluginRegistrant.kt
@@ -15,7 +15,7 @@ class SignedCallFlutterPluginRegistrant : FlutterPlugin {
      * This local reference serves to register the plugin with the Flutter Engine and unregister it
      * when the Flutter Engine is detached from the Activity
      */
-    var methodChannel: MethodChannel? = null
+    private var methodChannel: MethodChannel? = null
     private lateinit var methodCallHandler: MethodChannel.MethodCallHandler
 
     /**
@@ -24,8 +24,8 @@ class SignedCallFlutterPluginRegistrant : FlutterPlugin {
      * This local reference serves to create the pipeline and set the streamHandler
      *
      */
-    var callEventChannel: EventChannel? = null
-    var missedCallActionClickEventChannel: EventChannel? = null
+    private var callEventChannel: EventChannel? = null
+    private var missedCallActionClickEventChannel: EventChannel? = null
 
     var context: Context? = null
 

--- a/android/src/main/kotlin/com/clevertap/clevertap_signedcall_flutter/util/Utils.kt
+++ b/android/src/main/kotlin/com/clevertap/clevertap_signedcall_flutter/util/Utils.kt
@@ -1,6 +1,8 @@
 package com.clevertap.clevertap_signedcall_flutter.util
 
 import android.annotation.SuppressLint
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import com.clevertap.android.sdk.inapp.CTLocalInApp
 import com.clevertap.android.signedcall.exception.CallException
@@ -252,6 +254,30 @@ object Utils {
             "half-interstitial" -> CTLocalInApp.InAppType.HALF_INTERSTITIAL
             "alert" -> CTLocalInApp.InAppType.ALERT
             else -> null
+        }
+    }
+
+    /**
+     * Parses the given [value] to a Long.
+     *
+     * @return The Long value, or null if parsing is not possible.
+     */
+    fun parseLong(value: Any?): Long? {
+        return when (value) {
+            is Int -> value.toLong()
+            is Long -> value
+            else -> null
+        }
+    }
+
+    /**
+     * Runs the specified action on the main thread.
+     *
+     * @param action The code to be executed on the main thread.
+     */
+    fun runOnMainThread(action: () -> Unit) {
+        Handler(Looper.getMainLooper()).post {
+            action.invoke()
         }
     }
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -69,8 +69,8 @@ flutter {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.clevertap.android:clevertap-android-sdk:5.2.0"
-    implementation "com.clevertap.android:clevertap-signedcall-sdk:0.0.4"
+    implementation "com.clevertap.android:clevertap-android-sdk:5.2.2"
+    implementation "com.clevertap.android:clevertap-signedcall-sdk:0.0.5"
     implementation('io.socket:socket.io-client:2.1.0') {
         exclude group: 'org.json', module: 'json'
     }

--- a/example/android/app/src/main/kotlin/com/clevertap/signedcall_flutter_example/MyApplication.kt
+++ b/example/android/app/src/main/kotlin/com/clevertap/signedcall_flutter_example/MyApplication.kt
@@ -5,12 +5,14 @@ import com.clevertap.android.sdk.ActivityLifecycleCallback
 import com.clevertap.android.sdk.CleverTapAPI
 import com.clevertap.android.signedcall.fcm.SignedCallNotificationHandler
 import com.clevertap.android.signedcall.init.SignedCallAPI
+import com.clevertap.clevertap_signedcall_flutter.SCBackgroundCallEventHandler
 
 class MyApplication : Application() {
 
     override fun onCreate() {
         CleverTapAPI.setDebugLevel(CleverTapAPI.LogLevel.VERBOSE)
         SignedCallAPI.setDebugLevel(SignedCallAPI.LogLevel.VERBOSE)
+        SCBackgroundCallEventHandler.initialize(this)
         CleverTapAPI.setSignedCallNotificationHandler(SignedCallNotificationHandler())
         ActivityLifecycleCallback.register(this)
         super.onCreate()

--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>9.0</string>
+  <string>12.0</string>
 </dict>
 </plist>

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,13 +1,14 @@
 PODS:
-  - CleverTap-iOS-SDK (5.2.0):
+  - CleverTap-iOS-SDK (5.2.2):
     - SDWebImage (~> 5.11)
-  - CleverTap-SignedCall-SDK (0.0.5):
+  - CleverTap-SignedCall-SDK (0.0.6):
     - CleverTap-iOS-SDK
     - CTSimplePing (= 1.0.1)
     - CTSoftPhone (= 0.0.6-alpha)
     - Socket.IO-Client-Swift (= 16.0.1)
-  - clevertap_plugin (1.7.0):
-    - CleverTap-iOS-SDK (= 5.2.0)
+    - Starscream (= 4.0.4)
+  - clevertap_plugin (2.0.0):
+    - CleverTap-iOS-SDK (= 5.2.2)
     - Flutter
   - clevertap_signedcall_flutter (0.0.5):
     - CleverTap-SignedCall-SDK
@@ -17,23 +18,28 @@ PODS:
   - device_info_plus (0.0.1):
     - Flutter
   - Flutter (1.0.0)
+  - fluttertoast (0.0.2):
+    - Flutter
+    - Toast
   - permission_handler_apple (9.1.1):
     - Flutter
-  - SDWebImage (5.17.0):
-    - SDWebImage/Core (= 5.17.0)
-  - SDWebImage/Core (5.17.0)
+  - SDWebImage (5.18.10):
+    - SDWebImage/Core (= 5.18.10)
+  - SDWebImage/Core (5.18.10)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
   - Socket.IO-Client-Swift (16.0.1):
     - Starscream (~> 4.0)
-  - Starscream (4.0.6)
+  - Starscream (4.0.4)
+  - Toast (4.1.0)
 
 DEPENDENCIES:
   - clevertap_plugin (from `.symlinks/plugins/clevertap_plugin/ios`)
   - clevertap_signedcall_flutter (from `.symlinks/plugins/clevertap_signedcall_flutter/ios`)
   - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
   - Flutter (from `Flutter`)
+  - fluttertoast (from `.symlinks/plugins/fluttertoast/ios`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
 
@@ -47,6 +53,7 @@ SPEC REPOS:
     - SDWebImage
     - Socket.IO-Client-Swift
     - Starscream
+    - Toast
 
 EXTERNAL SOURCES:
   clevertap_plugin:
@@ -57,26 +64,30 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/device_info_plus/ios"
   Flutter:
     :path: Flutter
+  fluttertoast:
+    :path: ".symlinks/plugins/fluttertoast/ios"
   permission_handler_apple:
     :path: ".symlinks/plugins/permission_handler_apple/ios"
   shared_preferences_foundation:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
 
 SPEC CHECKSUMS:
-  CleverTap-iOS-SDK: 6a38eea6d2f0c336fb142baadcca2cd8aafd2290
-  CleverTap-SignedCall-SDK: 419fa35be344d1e65ab035dbbc4c2f827c8509d3
-  clevertap_plugin: 3bdba39d5b71cf5d9c40eb8a077efd5e2423eb43
-  clevertap_signedcall_flutter: af3402a7c8a9af82dfdf6b11cc55d9befd8b7763
+  CleverTap-iOS-SDK: 32d40735449b7b8f55a58a920e70ba7d59efa70d
+  CleverTap-SignedCall-SDK: 3079ed512b6bcd25f5acd79e1e814b3ec1a6e665
+  clevertap_plugin: 3a2bffe84f1c25a195e6a1a9068250a43db0a7aa
+  clevertap_signedcall_flutter: 37d621a28c41f325f30f81b756f4ba74646851fe
   CTSimplePing: b982a6095f50e8a6fffa1049c0f548e545d6f1a5
   CTSoftPhone: dd535d72050641b55cafea4adca2ce3bd1b26415
   device_info_plus: e5c5da33f982a436e103237c0c85f9031142abed
-  Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
+  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  fluttertoast: fafc4fa4d01a6a9e4f772ecd190ffa525e9e2d9c
   permission_handler_apple: e76247795d700c14ea09e3a2d8855d41ee80a2e6
-  SDWebImage: 750adf017a315a280c60fde706ab1e552a3ae4e9
-  shared_preferences_foundation: 5b919d13b803cadd15ed2dc053125c68730e5126
+  SDWebImage: fc8f2d48bbfd72ef39d70e981bd24a3f3be53fec
+  shared_preferences_foundation: b4c3b4cddf1c21f02770737f147a3f5da9d39695
   Socket.IO-Client-Swift: c116d6dc9fd6be9c259bacfe143f8725bce7d79e
-  Starscream: fb2c4510bebf908c62bd383bcf05e673720e91fd
+  Starscream: 5178aed56b316f13fa3bc55694e583d35dd414d9
+  Toast: ec33c32b8688982cecc6348adeae667c1b9938da
 
-PODFILE CHECKSUM: e032a40aa1d75b61d8170c8397a84598cec6ba45
+PODFILE CHECKSUM: c252209d835908944034ac66a198cdaa644d8970
 
 COCOAPODS: 1.12.0

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -141,7 +141,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
@@ -202,10 +202,12 @@
 		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
 			);
 			name = "Thin Binary";
 			outputPaths = (
@@ -216,6 +218,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -325,7 +328,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -341,7 +344,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 8;
 				DEVELOPMENT_TEAM = A5J34NR598;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -350,7 +353,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.1;
+				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.clevertap.signedCallDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -406,7 +409,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -455,7 +458,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -473,7 +476,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 8;
 				DEVELOPMENT_TEAM = A5J34NR598;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -482,7 +485,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.1;
+				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.clevertap.signedCallDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -499,7 +502,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 8;
 				DEVELOPMENT_TEAM = A5J34NR598;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -508,7 +511,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.1;
+				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.clevertap.signedCallDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,13 +1,37 @@
 import 'dart:async';
 
+import 'package:clevertap_signedcall_flutter/models/call_event_result.dart';
 import 'package:clevertap_signedcall_flutter/models/call_events.dart';
 import 'package:clevertap_signedcall_flutter/models/log_level.dart';
 import 'package:clevertap_signedcall_flutter/models/missed_call_action_click_result.dart';
 import 'package:clevertap_signedcall_flutter/plugin/clevertap_signedcall_flutter.dart';
+import 'package:clevertap_signedcall_flutter_example/pages/dialler_page.dart';
 import 'package:clevertap_signedcall_flutter_example/route_generator.dart';
 import 'package:flutter/material.dart';
 
+import 'Utils.dart';
+
+@pragma('vm:entry-point')
+void backgroundCallEventHandler(CallEventResult result) async {
+  debugPrint(
+      "backgroundCallEventHandler called from headless task with payload: $result");
+  Utils.showToast("${result.callEvent} is called!" );
+}
+
+@pragma('vm:entry-point')
+void backgroundMissedCallActionClickedHandler(
+    MissedCallActionClickResult result) async {
+  debugPrint(
+      "backgroundMissedCallActionClickedHandler called from headless task with payload: $result");
+  Utils.showToast("${result.action.actionLabel} is clicked!" );
+}
+
 void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+  CleverTapSignedCallFlutter.shared
+      .onBackgroundCallEvent(backgroundCallEventHandler);
+  CleverTapSignedCallFlutter.shared.onBackgroundMissedCallActionClicked(
+      backgroundMissedCallActionClickedHandler);
   runApp(const MyApp());
 }
 
@@ -19,7 +43,7 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-  late StreamSubscription<CallEvent>? _callEventSubscription;
+  late StreamSubscription<CallEventResult>? _callEventSubscription;
   late StreamSubscription<MissedCallActionClickResult>?
       _missedCallActionClickEventSubscription;
   static const int _callMeterDurationInSeconds = 15;
@@ -48,11 +72,11 @@ class _MyAppState extends State<MyApp> {
   //Listens to the real-time stream of call-events
   void _startObservingCallEvents() {
     _callEventSubscription =
-        CleverTapSignedCallFlutter.shared.callEventListener.listen((event) {
+        CleverTapSignedCallFlutter.shared.callEventListener.listen((result) {
       debugPrint(
-          "CleverTap:SignedCallFlutter: received callEvent stream with ${event.toString()}");
-      //Utils.showSnack(context, event.name);
-      if (event == CallEvent.callInProgress) {
+          "CleverTap:SignedCallFlutter: received callEvent stream with ${result.toString()}");
+      Utils.showToast("${result.callEvent} is called!" );
+      if (result.callEvent == CallEvent.callInProgress) {
         //_startCallDurationMeterToEndCall();
       }
     });
@@ -65,7 +89,9 @@ class _MyAppState extends State<MyApp> {
         .listen((result) {
       debugPrint(
           "CleverTap:SignedCallFlutter: received missedCallActionClickResult stream with ${result.toString()}");
-      //Navigator.pushNamed(context, <SomePage.routeName>);
+      Utils.showToast("${result.action.actionLabel} is clicked!" );
+
+      Navigator.pushNamed(context, DiallerPage.routeName);
     });
   }
 

--- a/example/lib/utils.dart
+++ b/example/lib/utils.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/material.dart';
+import 'package:fluttertoast/fluttertoast.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 import 'constants.dart';
@@ -15,6 +16,17 @@ class Utils {
 
   static void showSnack(BuildContext context, String text) {
     ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(text)));
+  }
+
+  static void showToast(String message) {
+    Fluttertoast.showToast(
+        msg: message,
+        toastLength: Toast.LENGTH_SHORT,
+        gravity: ToastGravity.CENTER,
+        timeInSecForIosWeb: 1,
+        backgroundColor: Colors.red,
+        textColor: Colors.white,
+        fontSize: 16.0);
   }
 
   static void dismissKeyboard(BuildContext context) {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       name: clevertap_plugin
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.0"
+    version: "1.9.1"
   clevertap_signedcall_flutter:
     dependency: "direct main"
     description:
@@ -63,7 +63,7 @@ packages:
       name: device_info_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.1.0"
+    version: "8.2.2"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -84,7 +84,7 @@ packages:
       name: ffi
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   file:
     dependency: transitive
     description:
@@ -103,7 +103,7 @@ packages:
       name: flutter_lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -114,6 +114,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  fluttertoast:
+    dependency: "direct main"
+    description:
+      name: fluttertoast
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "8.2.4"
   js:
     dependency: transitive
     description:
@@ -127,7 +134,7 @@ packages:
       name: lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   matcher:
     dependency: transitive
     description:
@@ -162,133 +169,119 @@ packages:
       name: path_provider_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.7"
+    version: "2.2.0"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.4"
+    version: "2.1.0"
   path_provider_windows:
     dependency: transitive
     description:
       name: path_provider_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.2.0"
   permission_handler:
     dependency: "direct main"
     description:
       name: permission_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "10.2.0"
+    version: "10.4.5"
   permission_handler_android:
     dependency: transitive
     description:
       name: permission_handler_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "10.2.0"
+    version: "10.3.6"
   permission_handler_apple:
     dependency: transitive
     description:
       name: permission_handler_apple
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.0.7"
+    version: "9.1.4"
   permission_handler_platform_interface:
     dependency: transitive
     description:
       name: permission_handler_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.9.0"
+    version: "3.12.0"
   permission_handler_windows:
     dependency: transitive
     description:
       name: permission_handler_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.2"
+    version: "0.1.3"
   platform:
     dependency: transitive
     description:
       name: platform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.1"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
-  process:
-    dependency: transitive
-    description:
-      name: process
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "4.2.4"
+    version: "2.1.5"
   shared_preferences:
     dependency: "direct main"
     description:
       name: shared_preferences
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.15"
+    version: "2.2.0"
   shared_preferences_android:
     dependency: transitive
     description:
       name: shared_preferences_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.12"
-  shared_preferences_ios:
+    version: "2.2.0"
+  shared_preferences_foundation:
     dependency: transitive
     description:
-      name: shared_preferences_ios
+      name: shared_preferences_foundation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.3.3"
   shared_preferences_linux:
     dependency: transitive
     description:
       name: shared_preferences_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
-  shared_preferences_macos:
-    dependency: transitive
-    description:
-      name: shared_preferences_macos
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.4"
+    version: "2.3.0"
   shared_preferences_platform_interface:
     dependency: transitive
     description:
       name: shared_preferences_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.3.0"
   shared_preferences_web:
     dependency: transitive
     description:
       name: shared_preferences_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.4"
+    version: "2.2.0"
   shared_preferences_windows:
     dependency: transitive
     description:
       name: shared_preferences_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.3.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -349,14 +342,14 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.7.0"
+    version: "4.1.4"
   xdg_directories:
     dependency: transitive
     description:
       name: xdg_directories
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0+2"
+    version: "1.0.2"
 sdks:
-  dart: ">=2.17.5 <3.0.0"
-  flutter: ">=3.0.0"
+  dart: ">=2.18.0 <3.0.0"
+  flutter: ">=3.3.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates how to use the clevertap_signedcall_flutter plugin.
 
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 environment:
   sdk: ">=2.17.5 <3.0.0"
@@ -19,9 +19,10 @@ dependencies:
     sdk: flutter
   clevertap_signedcall_flutter:
     path: ../
-  clevertap_plugin: ^1.6.0
+  clevertap_plugin: ^1.9.1
   permission_handler: ^10.2.0
   shared_preferences: ^2.0.15
+  fluttertoast: ^8.2.4
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
@@ -43,7 +44,6 @@ dev_dependencies:
 
 # The following section is specific to Flutter packages.
 flutter:
-
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the material Icons class.

--- a/ios/Classes/Constants.swift
+++ b/ios/Classes/Constants.swift
@@ -1,10 +1,49 @@
 import Foundation
 import SignedCallSDK
 
+public let SCCallStatusDidUpdate: NSNotification.Name = NSNotification.Name(rawValue: "SCCallStatusDidUpdate")
+
 enum SCChannel: String {
     case methodChannel = "clevertap_signedcall_flutter/methods"
     case eventChannel = "clevertap_signedcall_flutter/events/call_event"
 }
+
+struct SCCallEventMapping {
+    var callStatus: SCCallStatus?
+    var value: String {
+        switch callStatus {
+        case .CALL_DECLINED_DUE_TO_LOGGED_OUT_CUID:
+            "DeclinedDueToLoggedOutCuid"
+        case .CALLEE_MICROPHONE_PERMISSION_NOT_GRANTED:
+            "DeclinedDueToMicrophonePermissionsNotGranted"
+        case .CALL_IS_PLACED:
+            "CallIsPlaced"
+        case .CALLEE_BUSY_ON_ANOTHER_CALL:
+            "ReceiverBusyOnAnotherCall"
+        case .CALL_CANCELLED:
+            "Cancelled"
+        case .CALL_DECLINED:
+            "Declined"
+        case .CALL_MISSED:
+            "Missed"
+        case .CALL_ANSWERED:
+            "Answered"
+        case .CALL_IN_PROGRESS:
+            "CallInProgress"
+        case .CALL_OVER:
+            "Ended"
+        case .CALL_DECLINED_DUE_TO_NOTIFICATIONS_DISABLED:
+            "DeclinedDueToNotificationsDisabled"
+        case .DELAYED_ANSWER_ACTION:
+            ""
+        case .none:
+            "none"
+        @unknown default:
+            "unknow"
+        }
+    }
+}
+
 
 struct SCCallEvent: RawRepresentable {
     var rawValue: Int

--- a/ios/clevertap_signedcall_flutter.podspec
+++ b/ios/clevertap_signedcall_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'clevertap_signedcall_flutter'
-  s.version          = '0.0.5'
+  s.version          = '0.0.4'
   s.summary          = 'CleverTap SignedCall Flutter plugin.'
   s.description      = <<-DESC
   CleverTap SignedCall supports 1-1 voice calls.
@@ -15,9 +15,9 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'CleverTap-SignedCall-SDK'
+  s.dependency 'CleverTap-SignedCall-SDK', '0.0.6'
 
-  s.platform = :ios, '10.0'
+  s.platform = :ios, '12.0'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/lib/models/call_details.dart
+++ b/lib/models/call_details.dart
@@ -1,0 +1,23 @@
+import '../src/constants.dart';
+
+///Contains details about the missed call
+class CallDetails {
+  late String callerCuid;
+  late String calleeCuid;
+  late String callContext;
+  late String? initiatorImage;
+  late String? receiverImage;
+
+  CallDetails.fromMap(map) {
+    callerCuid = map[keyCallerCuid];
+    calleeCuid = map[keyCalleeCuid];
+    callContext = map[keyCallContext];
+    initiatorImage = map[keyInitiatorImage];
+    receiverImage = map[keyReceiverImage];
+  }
+
+  @override
+  String toString() {
+    return 'CallDetails{callerCuid: $callerCuid, calleeCuid: $calleeCuid, callContext: $callContext, initiatorImage: $initiatorImage, receiverImage: $receiverImage}';
+  }
+}

--- a/lib/models/call_event_result.dart
+++ b/lib/models/call_event_result.dart
@@ -1,0 +1,28 @@
+import '../src/constants.dart';
+import 'call_details.dart';
+import 'call_events.dart';
+
+/// Represents the result of a call event
+class CallEventResult {
+  late final CallDirection direction;
+  late final CallDetails callDetails;
+  late final CallEvent callEvent;
+
+  CallEventResult.fromMap(Map resultMap) {
+    direction = resultMap[keyDirection] == 'INCOMING'
+        ? CallDirection.incoming
+        : CallDirection.outgoing;
+
+    callDetails = CallDetails.fromMap(resultMap[keyCallDetails] ?? {});
+
+    callEvent = CallEvent.fromString(resultMap[keyCallEvent]);
+  }
+
+  @override
+  String toString() {
+    return 'CallEventResult{direction: $direction, callDetails: $callDetails, callEvent: $callEvent}';
+  }
+}
+
+/// Enumeration representing the direction of a call (incoming or outgoing).
+enum CallDirection { incoming, outgoing }

--- a/lib/models/call_events.dart
+++ b/lib/models/call_events.dart
@@ -2,31 +2,45 @@ import '../src/signed_call_logger.dart';
 
 ///Holds all the possible statuses of a VoIP call
 enum CallEvent {
-  //When a call is cancelled from the initiator's end
+  // Indicates that the call is successfully placed
+  callIsPlaced,
+
+  // Indicates that the call is cancelled from the initiator's end
   cancelled,
 
-  //When a call is declined from the receiver's end
+  // Indicates that the call is declined from the receiver's end
   declined,
 
-  //When a call is missed at the receiver's end
+  // Indicates that the call is missed at the receiver's end
   missed,
 
-  //When a call is picked up by the receiver
+  // Indicates that the call is picked up by the receiver
   answered,
 
-  //When connection to the receiver is established after the call is answered.
-  //Audio transfer begins at this state.
+  // Indicates that the connection to the receiver is established and the audio transfer begins at this state
   callInProgress,
 
-  //When a call has been ended.
+  // Indicates that the call has been ended.
   ended,
 
-  //When the receiver is busy on another call
-  receiverBusyOnAnotherCall;
+  // Indicates that the receiver is already busy on another call
+  receiverBusyOnAnotherCall,
+
+  // Indicates that the call is declined due to the receiver being logged out with the specific CUID
+  declinedDueToLoggedOutCuid,
+
+  // [Specific to Android-Platform]
+  // Indicates that the call is declined due to the notifications are disabled at the receiver's end.
+  declinedDueToNotificationsDisabled,
+
+  // Indicates that the microphone permission is not granted for the call.
+  declinedDueToMicrophonePermissionsNotGranted;
 
   ///parses the state of the call in a [CallEvent]
   static CallEvent fromString(String state) {
     switch (state) {
+      case "CallIsPlaced":
+        return CallEvent.callIsPlaced;
       case "Cancelled":
         return CallEvent.cancelled;
       case "Declined":
@@ -41,6 +55,12 @@ enum CallEvent {
         return CallEvent.ended;
       case "ReceiverBusyOnAnotherCall":
         return CallEvent.receiverBusyOnAnotherCall;
+      case "DeclinedDueToLoggedOutCuid":
+        return CallEvent.declinedDueToLoggedOutCuid;
+      case "DeclinedDueToNotificationsDisabled":
+        return CallEvent.declinedDueToNotificationsDisabled;
+      case "DeclinedDueToMicrophonePermissionsNotGranted":
+        return CallEvent.declinedDueToMicrophonePermissionsNotGranted;
       default:
         SignedCallLogger.d('$state is not a valid CallState.');
         throw ArgumentError('$state is not a valid CallState.');

--- a/lib/models/missed_call_action_click_result.dart
+++ b/lib/models/missed_call_action_click_result.dart
@@ -1,5 +1,7 @@
 import 'package:clevertap_signedcall_flutter/src/constants.dart';
 
+import 'call_details.dart';
+
 ///Provides the call and action-button details associated to a missed call notification
 class MissedCallActionClickResult {
   late MissedCallNotificationAction action;
@@ -13,24 +15,6 @@ class MissedCallActionClickResult {
   @override
   String toString() {
     return 'MissedCallActionClickResult{action: $action, callDetails: $callDetails}';
-  }
-}
-
-///Contains details about the missed call
-class CallDetails {
-  late String callerCuid;
-  late String calleeCuid;
-  late String callContext;
-
-  CallDetails.fromMap(map) {
-    callerCuid = map[keyCallerCuid];
-    calleeCuid = map[keyCalleeCuid];
-    callContext = map[keyCallContext];
-  }
-
-  @override
-  String toString() {
-    return 'CallDetails{callerCuid: $callerCuid, calleeCuid: $calleeCuid, callContext: $callContext}';
   }
 }
 

--- a/lib/plugin/clevertap_signedcall_flutter.dart
+++ b/lib/plugin/clevertap_signedcall_flutter.dart
@@ -1,6 +1,6 @@
 import 'package:clevertap_signedcall_flutter/models/missed_call_action_click_result.dart';
 
-import '../models/call_events.dart';
+import '../models/call_event_result.dart';
 import '../models/log_level.dart';
 import '../src/signedcall_handlers.dart';
 import 'clevertap_signedcall_flutter_platform_interface.dart';
@@ -13,7 +13,7 @@ class CleverTapSignedCallFlutter {
   static CleverTapSignedCallFlutter get shared => _shared;
 
   static const sdkName = 'ctscsdkversion-flutter';
-  static const sdkVersion = 00003; /// If the current version is X.X.X then pass as X0X0X
+  static const sdkVersion = 00004; /// If the current version is X.X.X then pass as X0X0X
 
   /// This is a private named constructor.
   /// It'll be called exactly once only in this class,
@@ -58,7 +58,7 @@ class CleverTapSignedCallFlutter {
   }
 
   ///Returns the listener to listen the call-events stream
-  Stream<CallEvent> get callEventListener =>
+  Stream<CallEventResult> get callEventListener =>
       CleverTapSignedCallFlutterPlatform.instance.callEventsListener;
 
   ///Returns the listener to listen the call-events stream
@@ -90,5 +90,23 @@ class CleverTapSignedCallFlutter {
   ///Ends the active call, if any.
   Future<void> hangUpCall() {
     return CleverTapSignedCallFlutterPlatform.instance.hangUpCall();
+  }
+
+  /// Registers a callback to handle the call events when the app is in the
+  /// killed state.
+  ///
+  /// This provided handler must be a top-level function and cannot be
+  /// anonymous otherwise an [ArgumentError] will be thrown.
+  void onBackgroundCallEvent(BackgroundCallEventHandler handler) {
+    CleverTapSignedCallFlutterPlatform.instance.onBackgroundCallEvent(handler);
+  }
+
+  /// Registers a callback to handle the notification action clicked over missed call notification
+  /// when the app is in the killed state.
+  ///
+  /// This provided handler must be a top-level function and cannot be
+  /// anonymous otherwise an [ArgumentError] will be thrown.
+  void onBackgroundMissedCallActionClicked(BackgroundMissedCallActionClickedHandler handler) {
+    CleverTapSignedCallFlutterPlatform.instance.onBackgroundMissedCallActionClicked(handler);
   }
 }

--- a/lib/plugin/clevertap_signedcall_flutter_platform_interface.dart
+++ b/lib/plugin/clevertap_signedcall_flutter_platform_interface.dart
@@ -1,5 +1,6 @@
 import 'package:clevertap_signedcall_flutter/models/log_level.dart';
 
+import '../models/call_event_result.dart';
 import '../models/call_events.dart';
 import '../models/missed_call_action_click_result.dart';
 import '../src/signedcall_handlers.dart';
@@ -42,7 +43,15 @@ abstract class CleverTapSignedCallFlutterPlatform {
       SignedCallVoIPCallHandler voIPCallHandler);
 
   ///Broadcasts the [CallEvent] data stream to listen the real-time changes in the call-state.
-  Stream<CallEvent> get callEventsListener;
+  Stream<CallEventResult> get callEventsListener;
+
+  /// Registers a callback to handle the call events when the app is in the killed state.
+  void onBackgroundCallEvent(BackgroundCallEventHandler handler);
+
+  /// Registers a callback to handle the notification action clicked over missed call notification
+  /// when the app is in the killed state.
+  void onBackgroundMissedCallActionClicked(
+      BackgroundMissedCallActionClickedHandler handler);
 
   ///Broadcasts the [MissedCallActionClickResult]  data stream to listen the
   ///missed call action click events.

--- a/lib/src/callback_dispatcher.dart
+++ b/lib/src/callback_dispatcher.dart
@@ -1,0 +1,59 @@
+import 'dart:ui';
+
+import 'package:clevertap_signedcall_flutter/models/missed_call_action_click_result.dart';
+import 'package:clevertap_signedcall_flutter/src/signed_call_logger.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/services.dart';
+
+import '../models/call_event_result.dart';
+import 'constants.dart';
+
+// This is the entrypoint for the background isolate. Since we can only enter
+// an isolate once, we setup a MethodChannel to listen for method invocations
+// from the native portion of the plugin. This allows for the plugin to perform
+// any necessary processing in Dart (e.g., populating a custom object) before
+// invoking the provided callback.
+@pragma('vm:entry-point')
+void backgroundCallbackDispatcher() {
+  // Initialize state which is necessary for the MethodChannels.
+  WidgetsFlutterBinding.ensureInitialized();
+
+  const MethodChannel channel = MethodChannel(
+    '$channelName/background_isolate_channel',
+  );
+
+  // This is where we handle background events from the native portion of the plugin.
+  channel.setMethodCallHandler((
+    MethodCall call,
+  ) async {
+    SignedCallLogger.d(
+        "callbackDispatcher called with arguments: ${call.arguments}");
+
+    if (call.method == 'onBackgroundCallEvent' ||
+        call.method == 'onBackgroundMissedCallActionClicked') {
+      final CallbackHandle handle =
+          CallbackHandle.fromRawHandle(call.arguments['userCallbackHandle']);
+
+      // PluginUtilities.getCallbackFromHandle performs a lookup based on the
+      // callback handle and returns a tear-off of the original callback.
+      Function? callback = PluginUtilities.getCallbackFromHandle(handle);
+
+      try {
+        if (call.method == 'onBackgroundCallEvent') {
+          await callback!(CallEventResult.fromMap(call.arguments['payload']));
+        } else {
+          await callback!(
+              MissedCallActionClickResult.fromMap(call.arguments['payload']));
+        }
+      } catch (e) {
+        SignedCallLogger.d('An error occurred in your callbackDispatcher: $e');
+      }
+    } else {
+      throw UnimplementedError('${call.method} has not been implemented');
+    }
+  });
+
+  // Once we've finished initializing the callbackDispatcher, let the native portion of the plugin
+  // know that it can start the callback invocation.
+  channel.invokeMethod<void>('SCBackgroundCallbackDispatcher#initialized');
+}

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -4,6 +4,8 @@ const String argInitProperties = "initProperties";
 const String argCallProperties = "callProperties";
 const String keyReceiverCuid = "receiverCuid";
 const String keyCallContext = "callContext";
+const String keyInitiatorImage = "initiatorImage";
+const String keyReceiverImage = "receiverImage";
 const String keyCallOptions = "callOptions";
 const String keyAction = "action";
 const String keyActionId = "actionId";
@@ -14,3 +16,6 @@ const String keyCalleeCuid = "calleeCuid";
 const String keyErrorCode = "errorCode";
 const String keyErrorMessage = "errorMessage";
 const String keyErrorDescription = "errorDescription";
+const String keyDirection = "direction";
+const String keyCallEvent = "callEvent";
+

--- a/lib/src/handler_info.dart
+++ b/lib/src/handler_info.dart
@@ -1,0 +1,11 @@
+/// Contains information about a callback handler
+class HandlerInfo {
+  /// The callback handler function.
+  Function handler;
+
+  /// A flag indicating whether the handler has been initialized.
+  bool initialized;
+
+  /// Creates a [HandlerInfo] instance with the provided [handler] and optional [initialized] flag.
+  HandlerInfo({required this.handler, this.initialized = false});
+}

--- a/lib/src/signedcall_handlers.dart
+++ b/lib/src/signedcall_handlers.dart
@@ -1,4 +1,7 @@
+import 'package:clevertap_signedcall_flutter/models/missed_call_action_click_result.dart';
 import 'package:clevertap_signedcall_flutter/models/signed_call_error.dart';
+
+import '../models/call_event_result.dart';
 
 /// Contains all the Signed Call Handles with their aliases
 typedef SignedCallInitHandler = void Function(
@@ -6,3 +9,9 @@ typedef SignedCallInitHandler = void Function(
 
 typedef SignedCallVoIPCallHandler = void Function(
     SignedCallError? signedCallVoIPCallError);
+
+typedef BackgroundCallEventHandler = void Function(
+    CallEventResult callStatusDetails);
+
+typedef BackgroundMissedCallActionClickedHandler = void Function(
+    MissedCallActionClickResult callStatusDetails);

--- a/lib/src/signedcall_method_calls.dart
+++ b/lib/src/signedcall_method_calls.dart
@@ -7,6 +7,8 @@ class SCMethodCall {
   static const String logout = "logout";
   static const String hangUpCall = "hangUpCall";
   static const String logging = "logging";
+  static const String ackMissedCallActionClickedStream =
+      "missedCallActionClicked#ack";
 
   //Platform to Flutter
   static const String onSignedCallDidInitialize = "onSignedCallDidInitialize";

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: clevertap_signedcall_flutter
 description: The CleverTap's Signed Call Flutter provides an in-app calls service to make and receive calls in the mobile apps.
-version: 0.0.3
+version: 0.0.4
 homepage: https://github.com/CleverTap/clevertap-signedcall-flutter-sdk
 
 environment:

--- a/test/clevertap_signedcall_flutter_test.dart
+++ b/test/clevertap_signedcall_flutter_test.dart
@@ -1,4 +1,4 @@
-import 'package:clevertap_signedcall_flutter/models/call_events.dart';
+import 'package:clevertap_signedcall_flutter/models/call_event_result.dart';
 import 'package:clevertap_signedcall_flutter/models/log_level.dart';
 import 'package:clevertap_signedcall_flutter/models/missed_call_action_click_result.dart';
 import 'package:clevertap_signedcall_flutter/plugin/clevertap_signedcall_flutter_method_channel.dart';
@@ -23,7 +23,7 @@ class MockCleverTapDirectcallFlutterPlatform
   }
 
   @override
-  Stream<CallEvent> get callEventsListener => throw UnimplementedError();
+  Stream<CallEventResult> get callEventsListener => throw UnimplementedError();
 
   @override
   Future<void> hangUpCall() {
@@ -52,6 +52,16 @@ class MockCleverTapDirectcallFlutterPlatform
 
   @override
   Future<void> disconnectSignallingSocket() {
+    throw UnimplementedError();
+  }
+
+  @override
+  void onBackgroundCallEvent(BackgroundCallEventHandler handler) {
+    throw UnimplementedError();
+  }
+
+  @override
+  void onBackgroundMissedCallActionClicked(BackgroundMissedCallActionClickedHandler handler) {
     throw UnimplementedError();
   }
 }


### PR DESCRIPTION
**What's new**

* **[Android Platform]**
  * Supports [Signed Call Android SDK v0.0.5](https://repo1.maven.org/maven2/com/clevertap/android/clevertap-signedcall-sdk/0.0.5) which is compatible with [CleverTap Android SDK v5.2.2](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTCORECHANGELOG.md#version-522-december-22-2023).
  * Introduces new properties `initiatorImage` and `receiverImage` in the `MissedCallActionClickResult` instance provided through the `CleverTapSignedCallFlutter.shared.missedCallActionClickListener.listen(MissedCallActionClickResult)` event-stream.
  * Adds new public API registerVoIPCallStatusListener(SCVoIPCallStatusListener callStatusListener) to observe the changes in the call state, providing updates to both the initiator and receiver of the call.
  * Adds new callback APIs to handle events when the app is terminated or killed, as listed below:
    * Use `CleverTapSignedCallFlutter.shared.onBackgroundCallEvent(handler)` to handle VoIP call events when the app is in a killed state. 
    * Use `CleverTapSignedCallFlutter.shared.onBackgroundMissedCallActionClicked(handler)` to manage missed call action click events when the app is in a killed state.
      Please refer to the integration documentation for more details on handling callback events in a killed state.

* **[iOS Platform]**
  * Supports [Signed Call iOS SDK v0.0.6](https://github.com/CleverTap/clevertap-signedcall-ios-sdk/blob/main/CHANGELOG.md#version-006-january-19-2024) which is compatible with [CleverTap iOS SDK v5.2.2](https://github.com/CleverTap/clevertap-ios-sdk/blob/master/CHANGELOG.md#version-522-november-21-2023).
  
**Breaking Changes**

* **[Android and iOS Platform]**
  * The `CleverTapSignedCallFlutter.shared.callEventListener` event stream will now provide an instance of the `CallEventResult` class instead of the `CallEvent` class. Please refer to the integration documentation for details on usage.

**Behaviour Changes**

* **[Android Platform]**
  * Handles UX issues during network loss or switch by invalidating the socket reconnection and establishing an active connection to process the call related actions.
  * Modifies the SDK's behavior when the **Notifications Settings** are disabled for the application. Previously, if the app's notifications were disabled, the device rang on incoming calls without displaying the call screen in the background and killed states. In this version, the SDK now declines incoming calls when the notifications are disabled. If the notification settings are later enabled, the SDK resumes processing calls instead of automatically declining them.

* **[Android and iOS Platform]**
  * The `CleverTapSignedCallFlutter.shared.callEventListener` will now provide updates in the call state to both the initiator and receiver of the call. Previously, it was exposed only to the initiator of the call.
  
**Bug Fixes**

* **[Android Platform]**
  * Fixes multiple outgoing call requests initiated simultaneously through multiple calls of `CleverTapSignedCallFlutter.shared.call(..)`. The SDK now processes only one call at a time while rejecting other requests with a failure exception.
  * Addresses an **IllegalStateException** which occurs while prompting the user with the poor/bad network conditions on the call-screen.

* **[Android and iOS Platform]**
   * Addresses an infinite **Connecting** state issue on the call screen which was triggered by using CUIDs longer than 15 characters. In this version, the SDK extends support to CUIDs ranging from 5 to 50 characters.       
