### PR TITLE
[VC-616] Support Signed Call iOS SDK v0.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 ## CHANGE LOG
 
+### Version 0.0.5 (May 16, 2024 )
+-------------------------------------------
+
+**Added**
+* **[iOS Platform]**
+  * Supports [Signed Call iOS SDK v0.0.7](https://github.com/CleverTap/clevertap-signedcall-ios-sdk/blob/main/CHANGELOG.md#version-007-march-15-2024) which is compatible with [CleverTap iOS SDK v6.1.0](https://github.com/CleverTap/clevertap-ios-sdk/blob/master/CHANGELOG.md#version-610-february-22-2024) and higher.
+  * Supports [Socket.io v16.1.0](https://github.com/socketio/socket.io-client-swift/releases/tag/v16.1.0) and [Starscream v4.0.8](https://github.com/daltoniam/Starscream/releases/tag/4.0.8) dependency.
+  * Adds privacy manifest.
+  * Expose socket usage logging for debugging purpose.
+  
+**Bug Fixes**
+* **[iOS Platform]**
+  * Handles runtime exception caused by an incompatible deployment target assigned to the Starscream framework by the host application. The Signed Call iOS dependency uses the Starscream framework as a transitive dependency. The issue is now handled within the SDK.
+
 ### Version 0.0.4 (January 22, 2024 )
 -------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To get started, sign up [here](https://clevertap.com/live-product-demo/).
 
 ```yaml
 dependencies:
-  clevertap_signedcall_plugin: 0.0.4
+  clevertap_signedcall_plugin: 0.0.5
 ```
 
 - Run `flutter pub get` to install the SDK.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.clevertap.clevertap_signedcall_flutter'
-version '0.0.4'
+version '0.0.5'
 
 buildscript {
     ext.kotlin_version = '1.6.10'

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -33,7 +33,6 @@ flutter_ios_podfile_setup
 target 'Runner' do
   use_frameworks!
   use_modular_headers!
-  pod 'Starscream', '4.0.4'
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 end
 
@@ -42,7 +41,6 @@ post_install do |installer|
     flutter_additional_ios_build_settings(target)
     # Required by SignedCall
     target.build_configurations.each do |config|
-          config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '13.4'
           config.build_settings['BUILD_LIBRARY_FOR_DISTRIBUTION'] = 'YES'
       
       config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= [
@@ -53,7 +51,7 @@ post_install do |installer|
       ]
           xcconfig_path = config.base_configuration_reference.real_path
             xcconfig = File.read(xcconfig_path)
-            xcconfig_mod = xcconfig.gsub(/DT_TOOLCHAIN_DIR/, "TOOLCHAIN_DIR")
+            xcconfig_mod = xcconfig.gsub(/TOOLCHAIN_DIR/, "TOOLCHAIN_DIR")
             File.open(xcconfig_path, "w") { |file| file << xcconfig_mod }
       
     end

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,17 +1,17 @@
 PODS:
-  - CleverTap-iOS-SDK (5.2.2):
+  - CleverTap-iOS-SDK (6.2.1):
     - SDWebImage (~> 5.11)
-  - CleverTap-SignedCall-SDK (0.0.6):
+  - CleverTap-SignedCall-SDK (0.0.7):
     - CleverTap-iOS-SDK
     - CTSimplePing (= 1.0.1)
     - CTSoftPhone (= 0.0.6-alpha)
-    - Socket.IO-Client-Swift (= 16.0.1)
-    - Starscream (= 4.0.4)
-  - clevertap_plugin (2.0.0):
-    - CleverTap-iOS-SDK (= 5.2.2)
+    - Socket.IO-Client-Swift (= 16.1.0)
+    - Starscream (= 4.0.8)
+  - clevertap_plugin (2.4.0):
+    - CleverTap-iOS-SDK (= 6.2.1)
     - Flutter
   - clevertap_signedcall_flutter (0.0.5):
-    - CleverTap-SignedCall-SDK
+    - CleverTap-SignedCall-SDK (= 0.0.7)
     - Flutter
   - CTSimplePing (1.0.1)
   - CTSoftPhone (0.0.6-alpha)
@@ -23,16 +23,16 @@ PODS:
     - Toast
   - permission_handler_apple (9.1.1):
     - Flutter
-  - SDWebImage (5.18.10):
-    - SDWebImage/Core (= 5.18.10)
-  - SDWebImage/Core (5.18.10)
+  - SDWebImage (5.19.2):
+    - SDWebImage/Core (= 5.19.2)
+  - SDWebImage/Core (5.19.2)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - Socket.IO-Client-Swift (16.0.1):
-    - Starscream (~> 4.0)
-  - Starscream (4.0.4)
-  - Toast (4.1.0)
+  - Socket.IO-Client-Swift (16.1.0):
+    - Starscream (~> 4.0.6)
+  - Starscream (4.0.8)
+  - Toast (4.1.1)
 
 DEPENDENCIES:
   - clevertap_plugin (from `.symlinks/plugins/clevertap_plugin/ios`)
@@ -42,7 +42,6 @@ DEPENDENCIES:
   - fluttertoast (from `.symlinks/plugins/fluttertoast/ios`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
-  - Starscream (= 4.0.4)
 
 SPEC REPOS:
   https://github.com/CleverTap/podspecs.git:
@@ -73,22 +72,22 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
 
 SPEC CHECKSUMS:
-  CleverTap-iOS-SDK: 32d40735449b7b8f55a58a920e70ba7d59efa70d
-  CleverTap-SignedCall-SDK: 3079ed512b6bcd25f5acd79e1e814b3ec1a6e665
-  clevertap_plugin: 3a2bffe84f1c25a195e6a1a9068250a43db0a7aa
-  clevertap_signedcall_flutter: 37d621a28c41f325f30f81b756f4ba74646851fe
+  CleverTap-iOS-SDK: 78ea6d752d84918f0426f7b3959777d862bcb348
+  CleverTap-SignedCall-SDK: 9c74fbac2e236fff9b02eaa0961970ab03546469
+  clevertap_plugin: 81d30133ce84661238d3dc02d1321e15cfe46e12
+  clevertap_signedcall_flutter: 633bb5dce41579ef7eaebfda8b43128f6730f69e
   CTSimplePing: b982a6095f50e8a6fffa1049c0f548e545d6f1a5
   CTSoftPhone: dd535d72050641b55cafea4adca2ce3bd1b26415
   device_info_plus: e5c5da33f982a436e103237c0c85f9031142abed
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  fluttertoast: fafc4fa4d01a6a9e4f772ecd190ffa525e9e2d9c
+  fluttertoast: 77ff8760d90ff5041a97e3d0c0ecaaa8472524d2
   permission_handler_apple: e76247795d700c14ea09e3a2d8855d41ee80a2e6
-  SDWebImage: fc8f2d48bbfd72ef39d70e981bd24a3f3be53fec
-  shared_preferences_foundation: b4c3b4cddf1c21f02770737f147a3f5da9d39695
-  Socket.IO-Client-Swift: c116d6dc9fd6be9c259bacfe143f8725bce7d79e
-  Starscream: 5178aed56b316f13fa3bc55694e583d35dd414d9
-  Toast: ec33c32b8688982cecc6348adeae667c1b9938da
+  SDWebImage: dfe95b2466a9823cf9f0c6d01217c06550d7b29a
+  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
+  Socket.IO-Client-Swift: ee4b8f80a3db18dd7f32b266ddf273310609443c
+  Starscream: 19b5533ddb925208db698f0ac508a100b884a1b9
+  Toast: 1f5ea13423a1e6674c4abdac5be53587ae481c4e
 
-PODFILE CHECKSUM: c252209d835908944034ac66a198cdaa644d8970
+PODFILE CHECKSUM: fef9a99cc662e59bf22db150e5b685019051e74e
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.11.2

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -29,17 +29,17 @@ packages:
     dependency: "direct main"
     description:
       name: clevertap_plugin
-      sha256: "452db7ddba3672991aede20c62657a0f6b4af13e073564f8572573a8e5f707c3"
+      sha256: db23be13cbb36dc2057728fd809912a84f7c65c4c8a0769faeceeeb216b514c8
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "2.4.0"
   clevertap_signedcall_flutter:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "0.0.3"
+    version: "0.0.5"
   clock:
     dependency: transitive
     description:
@@ -60,10 +60,10 @@ packages:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      sha256: d57953e10f9f8327ce64a508a355f0b1ec902193f66288e8cb5070e7c47eeb2d
+      sha256: ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.6"
+    version: "1.0.8"
   device_info_plus:
     dependency: "direct main"
     description:
@@ -92,10 +92,10 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: "7bf0adc28a23d395f19f3f1eb21dd7cfd1dd9f8e1c50051c069122e6853bc878"
+      sha256: "493f37e7df1804778ff3a53bd691d8692ddf69702cf4c1c1096a2e41b4779e21"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "2.1.2"
   file:
     dependency: transitive
     description:
@@ -116,7 +116,7 @@ packages:
       sha256: a25a15ebbdfc33ab1cd26c63a6ee519df92338a9c10f122adda92938253bef04
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.3"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -131,16 +131,42 @@ packages:
     dependency: "direct main"
     description:
       name: fluttertoast
-      url: "https://pub.dartlang.org"
+      sha256: "81b68579e23fcbcada2db3d50302813d2371664afe6165bc78148050ab94bf66"
+      url: "https://pub.dev"
     source: hosted
-    version: "8.2.4"
+    version: "8.2.5"
   js:
     dependency: transitive
     description:
       name: js
-      url: "https://pub.dartlang.org"
+      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
+      url: "https://pub.dev"
     source: hosted
-    version: "0.6.4"
+    version: "0.7.1"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.0"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -148,39 +174,39 @@ packages:
       sha256: "0a217c6c989d21039f1498c3ed9f3ed71b354e69873f13a8dfc3c9fe76f1b452"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   path_provider_linux:
     dependency: transitive
     description:
@@ -188,7 +214,7 @@ packages:
       sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.2.1"
   path_provider_platform_interface:
     dependency: transitive
     description:
@@ -196,7 +222,7 @@ packages:
       sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   path_provider_windows:
     dependency: transitive
     description:
@@ -204,7 +230,7 @@ packages:
       sha256: "8bc9f22eee8690981c22aa7fc602f5c85b497a6fb2ceb35ee5a5e5ed85ad8170"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.2.1"
   permission_handler:
     dependency: "direct main"
     description:
@@ -252,44 +278,47 @@ packages:
       sha256: "12220bb4b65720483f8fa9450b4332347737cf8213dd2840d8b2c823e47243ec"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.4"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.5"
+    version: "2.1.8"
   shared_preferences:
     dependency: "direct main"
     description:
       name: shared_preferences
-      sha256: "81429e4481e1ccfb51ede496e916348668fd0921627779233bd24cc3ff6abd02"
+      sha256: d3bbe5553a986e83980916ded2f0b435ef2e1893dfaa29d5a7a790d0eca12180
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.2.3"
   shared_preferences_android:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: "8568a389334b6e83415b6aae55378e158fbc2314e074983362d20c562780fb06"
+      sha256: "1ee8bf911094a1b592de7ab29add6f826a7331fb854273d55918693d5364a1f2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.2.2"
   shared_preferences_foundation:
     dependency: transitive
     description:
       name: shared_preferences_foundation
-      url: "https://pub.dartlang.org"
+      sha256: "0a8a893bf4fd1152f93fec03a415d11c27c74454d96e2318a7ac38dd18683ab7"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.3.3"
+    version: "2.4.0"
   shared_preferences_linux:
     dependency: transitive
     description:
       name: shared_preferences_linux
-      url: "https://pub.dartlang.org"
+      sha256: "9f2cbcf46d4270ea8be39fa156d86379077c8a5228d9dfdb1164ae0bb93f1faa"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "2.3.2"
   shared_preferences_platform_interface:
     dependency: transitive
     description:
@@ -297,15 +326,15 @@ packages:
       sha256: "22e2ecac9419b4246d7c22bfbbda589e3acf5c0351137d87dd2939d984d37c3b"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "2.3.2"
   shared_preferences_web:
     dependency: transitive
     description:
       name: shared_preferences_web
-      sha256: "7b15ffb9387ea3e237bb7a66b8a23d2147663d391cafc5c8f37b2e7b4bde5d21"
+      sha256: "9aee1089b36bd2aafe06582b7d7817fd317ef05fc30e6ba14bff247d0933042a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.0"
   shared_preferences_windows:
     dependency: transitive
     description:
@@ -313,7 +342,7 @@ packages:
       sha256: "841ad54f3c8381c480d0c9b508b89a34036f512482c407e6df7a9c4aa2ef8f59"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "2.3.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -375,14 +404,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.0.0"
   web:
     dependency: transitive
     description:
       name: web
-      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.5.1"
   win32:
     dependency: transitive
     description:
@@ -398,7 +435,7 @@ packages:
       sha256: faea9dee56b520b55a566385b84f2e8de55e7496104adada9962e0bd11bcff1d
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.4"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
-  flutter: ">=3.3.0"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.19.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
     sdk: flutter
   clevertap_signedcall_flutter:
     path: ../
-  clevertap_plugin: ^1.9.1
+  clevertap_plugin: ^2.4.0
   permission_handler: ^10.2.0
   shared_preferences: ^2.0.15
   fluttertoast: ^8.2.4
@@ -38,8 +38,6 @@ dev_dependencies:
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
   flutter_lints: ^2.0.0
-dependency_overrides:
-  clevertap_plugin: ^1.9.1
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 

--- a/ios/clevertap_signedcall_flutter.podspec
+++ b/ios/clevertap_signedcall_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'clevertap_signedcall_flutter'
-  s.version          = '0.0.4'
+  s.version          = '0.0.5'
   s.summary          = 'CleverTap SignedCall Flutter plugin.'
   s.description      = <<-DESC
   CleverTap SignedCall supports 1-1 voice calls.

--- a/ios/clevertap_signedcall_flutter.podspec
+++ b/ios/clevertap_signedcall_flutter.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'CleverTap-SignedCall-SDK', '0.0.6'
+  s.dependency 'CleverTap-SignedCall-SDK', '0.0.7'
 
   s.platform = :ios, '12.0'
 

--- a/lib/plugin/clevertap_signedcall_flutter.dart
+++ b/lib/plugin/clevertap_signedcall_flutter.dart
@@ -13,7 +13,7 @@ class CleverTapSignedCallFlutter {
   static CleverTapSignedCallFlutter get shared => _shared;
 
   static const sdkName = 'ctscsdkversion-flutter';
-  static const sdkVersion = 00004; /// If the current version is X.X.X then pass as X0X0X
+  static const sdkVersion = 00005; /// If the current version is X.X.X then pass as X0X0X
 
   /// This is a private named constructor.
   /// It'll be called exactly once only in this class,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: clevertap_signedcall_flutter
 description: The CleverTap's Signed Call Flutter provides an in-app calls service to make and receive calls in the mobile apps.
-version: 0.0.4
+version: 0.0.5
 homepage: https://github.com/CleverTap/clevertap-signedcall-flutter-sdk
 
 environment:


### PR DESCRIPTION
**Added**
* **[iOS Platform]**
  * Supports [Signed Call iOS SDK v0.0.7](https://github.com/CleverTap/clevertap-signedcall-ios-sdk/blob/main/CHANGELOG.md#version-007-march-15-2024) which is compatible with [CleverTap iOS SDK v6.1.0](https://github.com/CleverTap/clevertap-ios-sdk/blob/master/CHANGELOG.md#version-610-february-22-2024) and higher.
  * Supports [Socket.io v16.1.0](https://github.com/socketio/socket.io-client-swift/releases/tag/v16.1.0) and [Starscream v4.0.8](https://github.com/daltoniam/Starscream/releases/tag/4.0.8) dependency.
  * Adds privacy manifest.
  * Expose socket usage logging for debugging purpose.
  
**Bug Fixes**
* **[iOS Platform]**
  * Handles runtime exception caused by an incompatible deployment target assigned to the Starscream framework by the host application. The Signed Call iOS dependency uses the Starscream framework as a transitive dependency. The issue is now handled within the SDK.
